### PR TITLE
Fix documentation example

### DIFF
--- a/lib/castkit/serializers/base.rb
+++ b/lib/castkit/serializers/base.rb
@@ -15,7 +15,7 @@ module Castkit
     #     private
     #
     #     def call
-    #       { type: object.class.name, data: object.to_h }
+    #       { type: object.class.name, data: {stuff: object.stuff} }
     #     end
     #   end
     #


### PR DESCRIPTION
Calling object.to_h inside a custom serializer's `call` method causes an infinite loop, ending with "stack level too deep", since the `to_h` will invoke the custom serializer.

I don't think this is a "good" replacement example, but I'm not sure what would be. I'm  trying to figure out how to write a proper custom serializer, but haven't yet.